### PR TITLE
Use SemVer 3 digits version

### DIFF
--- a/logux/__init__.py
+++ b/logux/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'Django Logux integration engine'
-__version__ = "0.1"
+__version__ = "0.1.0"
 __author__ = 'Vadim Iskuchekov @egregors'
 __license__ = 'MIT License'
 


### PR DESCRIPTION
DO we need use SemVer `x.x.x` versions or pip will convert `0.1` to `0.1.0` automatically?